### PR TITLE
Fix combat logs

### DIFF
--- a/src/pages/battle/battle.ts
+++ b/src/pages/battle/battle.ts
@@ -35,7 +35,7 @@ export class BattlePage extends PlayComponent implements OnInit, OnDestroy {
     const battleName = this.navParams.get('battleName');
     this.battle$ = this.appState.battle.subscribe(battle => this.battle = battle);
     this.pet$ = this.appState.petactive.subscribe(pet => this.petName = pet.name);
-
+    this.battle.messageData = [ { data: null, message: 'Loading' } ];
     this.primus.loadBattle(battleName);
   }
 


### PR DESCRIPTION
Main problem: Battles were retrieved from db after page had already loaded and virtual scrolling was having problems loading the updated non-empty battle data.

Ionic 3.0 messed up whatever they fixed in 2.2 with regards to virtual scrolling. A possible fix would have been virtualtrackby, but that is broken in 3.0 (and possibly every other version) as well. I put in this placeholder messageData so that Ionic would load the battle log after it gets retrieved from the db.